### PR TITLE
fix: 当目标值为 -1 时不能工作

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -144,7 +144,7 @@ namespace ZZZConfigManager
             int targetPlatform = mobileMode.Value == 1 ? 1 : 2;
             raw = Regex.Replace(
                 raw,
-                "(LocalUILayoutPlatform\")(\\s*:\\s*)(\\d+)",
+                "(LocalUILayoutPlatform\")(\\s*:\\s*)(-?\\d+)",
                 m => $"{m.Groups[1].Value}{m.Groups[2].Value}{targetPlatform}"
             );
 


### PR DESCRIPTION
发现当目标值为-1时, 不能正常匹配并更改值。
修改正则以匹配负号